### PR TITLE
Fixed bug in send_alert method

### DIFF
--- a/send_alert.py
+++ b/send_alert.py
@@ -13,7 +13,7 @@ def send_alert(mobiles, message):
 
     # get one phone number at a time. phone numbers should be comma seperated.
     for mobile in mobiles:
-        message = client.messages \
+        message1 = client.messages \
             .create(
                 body=message,
                 from_=twilio_phone,


### PR DESCRIPTION
"message" attribute was wrongly used to store twilio client in send_alert method. This was causing issue with sms sent to users. Instead of actual message , user was getting twilio object.